### PR TITLE
transition from broom to broom.mixed (fixes #27)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,6 +27,7 @@ Description: Statistical methods that quantify the conditions necessary to alter
 License: MIT + file LICENSE
 Imports: 
     broom,
+    broom.mixed,
     crayon,
     dplyr,
     ggplot2,

--- a/R/konfound-lmer.R
+++ b/R/konfound-lmer.R
@@ -9,7 +9,7 @@ get_kr_df <- function(model_object) {
 }
 
 konfound_lmer <- function(model_object, tested_variable_string, test_all, alpha, tails, to_return) {
-  tidy_output <- broom::tidy(model_object) # tidying output
+  tidy_output <- broom.mixed::tidy(model_object) # tidying output
 
   if (test_all == FALSE) {
     coef_df <- tidy_output[tidy_output$term == tested_variable_string, ]


### PR DESCRIPTION
Hey there!

This PR fixes the issue noted in #27—tidiers from mixed models now live in the broom.mixed package rather than broom. We hope to submit broom to CRAN in the next week or so. I hope this is helpful in getting a new version up in the meantime.🙂